### PR TITLE
fixes from PVS-Studio

### DIFF
--- a/hash_list.cpp
+++ b/hash_list.cpp
@@ -208,13 +208,13 @@ UINT32 CHashedStringList::SuperFastHash (const TCHAR * data, int len)
 CHashedStringList::CHashedStringList():m_Size(100), m_bCaseSense(false), m_Count(0)
 {
 	m_hashitem = (CMHashItem*)malloc(m_Size * sizeof(CMHashItem));	//创建一个HashItem组
-	memset(m_hashitem, 0, m_Size * sizeof(CMHashItem));
+	if (m_hashitem) memset(m_hashitem, 0, m_Size * sizeof(CMHashItem));
 }
 
 CHashedStringList::CHashedStringList(int nSize, BOOL bCaseSensative):m_Size(nSize), m_bCaseSense(bCaseSensative), m_Count(0)
 {
 	m_hashitem = (CMHashItem*)malloc(nSize * sizeof(CMHashItem));	//创建一个HashItem组
-	memset(m_hashitem, 0, nSize * sizeof(CMHashItem));
+	if (m_hashitem) memset(m_hashitem, 0, nSize * sizeof(CMHashItem));
 }
 
 CHashedStringList::~CHashedStringList()


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V575](https://www.viva64.com/en/w/v575/) The potential null pointer is passed into 'memset' function. Inspect the first argument. hash_list.cpp 211,217