### PR TITLE
Substitute fonts in SearchUI (Cortana) and WinStore.App (Microsoft Store)

### DIFF
--- a/hooklist.h
+++ b/hooklist.h
@@ -209,6 +209,17 @@ HOOK_MANUALLY(HRESULT, CreateFontFace, (
 			  __out IDWriteFontFace** fontFace
 			  ))
 
+HOOK_MANUALLY(HRESULT, DWriteFontFaceReference_CreateFontFace, (
+			  IDWriteFontFaceReference* self,
+			  __out IDWriteFontFace3** fontFace
+			  ))
+
+HOOK_MANUALLY(HRESULT, DWriteFontFaceReference_CreateFontFaceWithSimulations, (
+			  IDWriteFontFaceReference* self,
+			  DWRITE_FONT_SIMULATIONS fontFaceSimulationFlags,
+			  __out IDWriteFontFace3** fontFace
+			  ))
+
 HOOK_MANUALLY(HRESULT, CreateBitmapRenderTarget, (
 			  IDWriteGdiInterop* This,
 			  HDC hdc,


### PR DESCRIPTION
I guess Edge WebView (edgehtml.dll) uses these methods. There are still a couple of methods that can be used to create IDWriteFontFace, but I haven't seen such cases yet. Now I'm done with DirectWrite for this time. Other issues are too hard to fix or I will just ignore them.