### PR TITLE
Get everything build with latest toolkits, simplify build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .vs/
 .vscode/
 deps/
+lib/
 Debug/
 Release/
 x64/

--- a/doc/HOWTOBUILD.md
+++ b/doc/HOWTOBUILD.md
@@ -1,62 +1,64 @@
-How to build
--------------
-
-Personally, I use Visual Studio 2013 (msvc) to build mactype and all its dependencies, however, I believe you can build them with other compiles.
-Here I will show you the steps I do to make the compilation.
+# How to build
 
  1. **Compiler / IDE**
-	
-    msvc is preferred, I have provided a solution of msvc2013 in the repo. If you are using msvc2013+, just open my solution and you are ready to go. For msvc version lower than 2013, you have to make your own project.
-	
- 2. **Dependencies**
-	 
-    Mactype depends on
-	 - Freetype ([link](https://www.freetype.org/download.html))
-	 - EasyHook ([link](http://easyhook.github.io/))
-	 - or Detours(obsolete, better not use)
-	 - iniParser (Get from my repo, orginal build is not fully functional)
-	 - wow64ext (Get from my repo, or from official repo, but you need to modify it yourself)
-	 - Windows sdk 10.0.14393.0 or later([link](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk))
 
-3. **Building dependencies**
-	- FreeType
-		
+    Visual Studio 2019 with v142 toolkit has been tested and is working. Toolkits down to v120 should be able to compile the code, but be aware that the `_xp` ones might refuse to use the Windows 10 SDK.
+
+ 2. **Dependencies**
+
+    Mactype depends on
+     - [Freetype](https://www.freetype.org/download.html)
+     - [EasyHook](http://easyhook.github.io/)
+     - or Detours (obsolete, better not use)
+     - [IniParser (fork)](https://github.com/snowie2000/IniParser)
+     - [wow64ext (fork)](https://github.com/snowie2000/rewolf-wow64ext)
+     - Windows SDK (10.0.14393.0 or later)
+
+ 3. **Building dependencies**
+
+    - FreeType
+
+        Apply `glyph_to_bitmapex.diff` before building.
+
         Always build multi-thread release.
 
-		Remember to enable options you want in ftoptions.h
-	
-		Compile freetype as Freetype.lib for x86 and freetype64.lib for x64
-	
-		Static library is preferred, you are free to build freetype as independent dlls with better interchangeability but you will lose some compatibility in return, for some programs are delivered with their own copies of freetype which will conflict with your file.
-	- iniParser
-	
-		Build as iniparser.lib and iniparser64.lib
-	
-	- wow64ext
-		
-		Build as wow64ext.lib. x64 library is not required. Dll library is also accepted (if you like).
-	
-	- EasyHook
-		
+        Remember to enable options you want in ftoptions.h
+
+        Compile freetype as freetype.lib for x86 and freetype64.lib for x64
+
+        Static library is preferred, you are free to build freetype as independent dlls with better interchangeability but you will lose some compatibility in return, for some programs are delivered with their own copies of freetype which will conflict with your file.
+
+        Set `FREETYPE_PATH` environment variable to root of freetype source.
+
+    - iniParser
+
+        Build as iniparser.lib and iniparser64.lib. Set `INI_PARSER_PATH` environment variable to root of IniParser project.
+
+    - wow64ext
+
+        Build as wow64ext.lib. x64 library is not required. Shared library also works if you prefer that.
+
+    - EasyHook
+
         Only EasyHookDll project is required.
 
-		Build it as easyhk32.lib and easyhk64.lib.
-	
-		Dll filename is not important but you'd better give it a special name to avoid dll confliction as I stated above.
-	- Windows SDK
-		
+        Build it as easyhook32.lib and easyhook64.lib, or get the binary distributions.
+
+        Dll filename is not important but you'd better give it a special name to avoid dll confliction as stated above. Do not forget to modify filename in `hook.cpp` of MacType.
+
+    - Windows SDK
+
         Actually it's not something you need to build, but the installation is tricky.
 
-		One word to rule them all: download **ALL COMPONENTS**  in the installation list! Unless you want to waste several hours looking for these mysterious dependencies it pops to you. Don't worry, you will have a second chance to choose which component you want to install after download.
-		
-4. **Build**
+        One word to rule them all: download **ALL COMPONENTS**  in the installation list! Unless you want to waste several hours looking for these mysterious dependencies it pops to you. Don't worry, you will have a second chance to choose which component you want to install after download.
 
-	Last but simplest step. Put all files you builds in the above steps to MacType folder, set up VC++ folders and hit F7.
-	Enjoy. 
+ 4. **Build**
 
-FAQ
--------
-Q: Where are the sources of loader and tunner in the repo?
+    Last but easiest step: Put all `.lib` files you built earlier into a `lib` folder in the root of MacType, click build and enjoy.
 
-A: I'm sorry, but they are still close-source right now. Since you have the mactype source and will surely have a good understanding of how mactype works, I believe it's not a big challenge to write a loader for it.
-If you wrote a great loader or something else wonderful, don't forget to send me link~
+## FAQ
+
+Q: Where are the sources of loader and tuner in the repo?
+
+A: I'm sorry, but they are still closed-source right now. Since you have the mactype source and will surely have a good understanding of how mactype works, I believe it's not a big challenge to write a loader for it.
+If you wrote a great loader or something else wonderful, please post an issue or a pull request. Hope we can make MacType better!

--- a/doc/glyph_to_bitmapex.diff
+++ b/doc/glyph_to_bitmapex.diff
@@ -1,0 +1,126 @@
+ src/base/ftglyph.c | 112 +++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 112 insertions(+)
+
+diff --git a/src/base/ftglyph.c b/src/base/ftglyph.c
+index 27402ecf8..7637388a8 100644
+--- a/src/base/ftglyph.c
++++ b/src/base/ftglyph.c
+@@ -634,6 +634,118 @@
+   }
+ 
+ 
++FT_EXPORT_DEF(FT_Error)
++	FT_Glyph_To_BitmapEx(FT_Glyph*       the_glyph,
++		FT_Render_Mode  render_mode,
++		FT_Vector*      origin,
++		FT_Bool         destroy,
++		FT_Bool			loadcolor,
++		FT_UInt			glyphindex,
++		FT_Face			face)
++{
++	FT_GlyphSlotRec           dummy;
++	FT_GlyphSlot_InternalRec  dummy_internal;
++	FT_Error                  error = FT_Err_Ok;
++	FT_Glyph                  b, glyph;
++	FT_BitmapGlyph            bitmap = NULL;
++	const FT_Glyph_Class*     clazz;
++
++	FT_Library                library;
++
++
++	/* check argument */
++	if (!the_glyph)
++		goto Bad;
++	glyph = *the_glyph;
++	if (!glyph)
++		goto Bad;
++
++	clazz = glyph->clazz;
++	library = glyph->library;
++	if (!library || !clazz)
++		goto Bad;
++
++	/* when called with a bitmap glyph, do nothing and return successfully */
++	if (clazz == &ft_bitmap_glyph_class)
++		goto Exit;
++
++	if (!clazz->glyph_prepare)
++		goto Bad;
++
++	/* we render the glyph into a glyph bitmap using a `dummy' glyph slot */
++	/* then calling FT_Render_Glyph_Internal()                            */
++
++	FT_ZERO(&dummy);
++	FT_ZERO(&dummy_internal);
++	dummy.internal = &dummy_internal;
++	dummy.library = library;
++	dummy.format = clazz->glyph_format;
++	
++	if (loadcolor) {
++		dummy_internal.load_flags |= FT_LOAD_COLOR;
++		dummy.glyph_index = glyphindex;
++		dummy.face = face;
++	}
++
++	/* create result bitmap glyph */
++	error = ft_new_glyph(library, &ft_bitmap_glyph_class, &b);
++	if (error)
++		goto Exit;
++	bitmap = (FT_BitmapGlyph)b;
++
++#if 1
++	/* if `origin' is set, translate the glyph image */
++	if (origin)
++		FT_Glyph_Transform(glyph, 0, origin);
++#else
++	FT_UNUSED(origin);
++#endif
++
++	/* prepare dummy slot for rendering */
++	error = clazz->glyph_prepare(glyph, &dummy);
++	if (!error)
++		error = FT_Render_Glyph_Internal(glyph->library, &dummy, render_mode);
++
++#if 1
++	if (!destroy && origin)
++	{
++		FT_Vector  v;
++
++
++		v.x = -origin->x;
++		v.y = -origin->y;
++		FT_Glyph_Transform(glyph, 0, &v);
++	}
++#endif
++
++	if (error)
++		goto Exit;
++
++	/* in case of success, copy the bitmap to the glyph bitmap */
++	error = ft_bitmap_glyph_init((FT_Glyph)bitmap, &dummy);
++	if (error)
++		goto Exit;
++
++	/* copy advance */
++	bitmap->root.advance = glyph->advance;
++
++	if (destroy)
++		FT_Done_Glyph(glyph);
++
++	*the_glyph = FT_GLYPH(bitmap);
++
++Exit:
++	if (error && bitmap)
++		FT_Done_Glyph(FT_GLYPH(bitmap));
++
++	return error;
++
++Bad:
++	error = FT_THROW(Invalid_Argument);
++	goto Exit;
++}
++
++
+   /* documentation is in ftglyph.h */
+ 
+   FT_EXPORT_DEF( void )

--- a/ft.cpp
+++ b/ft.cpp
@@ -99,6 +99,16 @@ void Log(wchar_t* Msg)
 	fclose(f);
 }
 
+FT_EXPORT_DEF(FT_Error)
+FT_Glyph_To_BitmapEx(FT_Glyph* the_glyph,
+	FT_Render_Mode  render_mode,
+	FT_Vector* origin,
+	FT_Bool         destroy,
+	FT_Bool			loadcolor,
+	FT_UInt			glyphindex,
+	FT_Face			face);
+
+
 class CAlphaBlend
 {
 private:

--- a/gdidll.rc
+++ b/gdidll.rc
@@ -7,7 +7,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+#include "winres.h"
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
 

--- a/gdipp.vcxproj
+++ b/gdipp.vcxproj
@@ -55,73 +55,73 @@
     <ProjectGuid>{15C33FD9-0811-4981-B08F-E0BAD74A3028}</ProjectGuid>
     <RootNamespace>gdipp</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Infinality|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Infinality|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Infinality|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Infinality|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Infinality|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Infinality|ARM'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
@@ -173,7 +173,8 @@
     <LinkIncremental>true</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName).Core</TargetName>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK);D:\Archives\Documents\Visual Studio 2013\Projects\IniParser;D:\Archives\Documents\Visual Studio 2008\Projects\freetype2\include</IncludePath>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Infinality|Win32'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
@@ -181,7 +182,8 @@
     <LinkIncremental>true</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName).Core</TargetName>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK);D:\Archives\Documents\Visual Studio 2013\Projects\IniParser;D:\Archives\Documents\Visual Studio 2008\Projects\freetype2\include</IncludePath>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
@@ -189,7 +191,8 @@
     <LinkIncremental>true</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName)64.Core</TargetName>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);D:\Archives\Documents\Visual Studio 2013\Projects\IniParser;D:\Archives\Documents\Visual Studio 2008\Projects\freetype2\include</IncludePath>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Infinality|x64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
@@ -197,7 +200,8 @@
     <LinkIncremental>true</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName)64.Core</TargetName>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);D:\Archives\Documents\Visual Studio 2013\Projects\IniParser;D:\Archives\Documents\Visual Studio 2008\Projects\freetype2\include</IncludePath>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
@@ -205,6 +209,8 @@
     <LinkIncremental>true</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName)64.Core</TargetName>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Infinality|ARM'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
@@ -212,6 +218,8 @@
     <LinkIncremental>true</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName)64.Core</TargetName>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
@@ -219,7 +227,8 @@
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName).Core</TargetName>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK);D:\Archives\Documents\Visual Studio 2013\Projects\IniParser;D:\Archives\Documents\Visual Studio 2008\Projects\freetype2\include</IncludePath>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Infinality|Win32'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
@@ -227,7 +236,8 @@
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName).Core</TargetName>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK);D:\Archives\Documents\Visual Studio 2013\Projects\IniParser;D:\Archives\Documents\Visual Studio 2008\Projects\freetype2\include</IncludePath>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
@@ -235,7 +245,8 @@
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName)64.Core</TargetName>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);D:\Archives\Documents\Visual Studio 2013\Projects\IniParser;D:\Archives\Documents\Visual Studio 2008\Projects\freetype2\include</IncludePath>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Infinality|x64'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
@@ -243,7 +254,8 @@
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName)64.Core</TargetName>
-    <IncludePath>$(VC_IncludePath);$(WindowsSDK_IncludePath);D:\Archives\Documents\Visual Studio 2013\Projects\IniParser;D:\Archives\Documents\Visual Studio 2008\Projects\freetype2\include</IncludePath>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
@@ -251,6 +263,8 @@
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName)64.Core</TargetName>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Infinality|ARM'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
@@ -258,6 +272,8 @@
     <LinkIncremental>false</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
     <TargetName>$(ProjectName)64.Core</TargetName>
+    <IncludePath>$(INI_PARSER_PATH);$(FREETYPE_PATH)\include;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)lib;$(LibraryPath)</LibraryPath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -282,7 +298,7 @@
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
       <TargetMachine>MachineX86</TargetMachine>
       <AdditionalOptions>/DEBUG</AdditionalOptions>
-      <DelayLoadDLLs>Easyhk32.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook32.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug Infinality|Win32'">
@@ -309,7 +325,7 @@
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
       <TargetMachine>MachineX86</TargetMachine>
       <AdditionalOptions>/DEBUG</AdditionalOptions>
-      <DelayLoadDLLs>Easyhk32.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook32.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -338,7 +354,7 @@
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
       <TargetMachine>MachineX64</TargetMachine>
       <AdditionalOptions>/DEBUG %(AdditionalOptions)</AdditionalOptions>
-      <DelayLoadDLLs>Easyhk64.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook64.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug Infinality|x64'">
@@ -368,7 +384,7 @@
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
       <TargetMachine>MachineX64</TargetMachine>
       <AdditionalOptions>/DEBUG %(AdditionalOptions)</AdditionalOptions>
-      <DelayLoadDLLs>Easyhk64.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook64.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
@@ -395,7 +411,7 @@
       <SubSystem>Windows</SubSystem>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
       <AdditionalOptions>/DEBUG %(AdditionalOptions)</AdditionalOptions>
-      <DelayLoadDLLs>Easyhk64.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook64.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug Infinality|ARM'">
@@ -422,7 +438,7 @@
       <SubSystem>Windows</SubSystem>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
       <AdditionalOptions>/DEBUG %(AdditionalOptions)</AdditionalOptions>
-      <DelayLoadDLLs>Easyhk64.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook64.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -455,7 +471,7 @@
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
       <TargetMachine>MachineX86</TargetMachine>
-      <DelayLoadDLLs>Easyhk32.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook32.dll</DelayLoadDLLs>
       <AdditionalLibraryDirectories>$(SolutionDir)deps\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -488,7 +504,7 @@
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
       <TargetMachine>MachineX86</TargetMachine>
-      <DelayLoadDLLs>Easyhk32.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook32.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -521,7 +537,7 @@
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
       <TargetMachine>MachineX64</TargetMachine>
-      <DelayLoadDLLs>Easyhk64.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook64.dll</DelayLoadDLLs>
       <AdditionalLibraryDirectories>$(SolutionDir)deps\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
@@ -555,7 +571,7 @@
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
       <TargetMachine>MachineX64</TargetMachine>
-      <DelayLoadDLLs>Easyhk64.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook64.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -585,7 +601,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
-      <DelayLoadDLLs>Easyhk64.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook64.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Infinality|ARM'">
@@ -615,7 +631,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <SupportUnloadOfDelayLoadedDLL>true</SupportUnloadOfDelayLoadedDLL>
-      <DelayLoadDLLs>Easyhk64.dll</DelayLoadDLLs>
+      <DelayLoadDLLs>easyhook64.dll</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/hash_list.h
+++ b/hash_list.h
@@ -3,6 +3,7 @@
 #include "string.h"
 #include "windows.h"
 #include <map>
+#include <string>
 
 typedef std::map<std::wstring, LPTSTR> strmap;
 

--- a/hook.cpp
+++ b/hook.cpp
@@ -1,13 +1,13 @@
 // API hook
 //
-// GetProcAddressï¿½Å“ï¿½ï¿½ï¿½callï¿½ï¿½iï¿½Öï¿½ï¿½{ï¿½Ìjï¿½ğ’¼Úï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½A
-// ï¿½ï¿½ï¿½ï¿½ï¿½Ìƒtï¿½bï¿½Nï¿½Öï¿½ï¿½ï¿½jmpï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
+// GetProcAddress‚Å“¾‚½callæiŠÖ”–{‘Ìj‚ğ’¼Ú‘‚«Š·‚¦A
+// ©•ª‚ÌƒtƒbƒNŠÖ”‚Éjmp‚³‚¹‚éB
 //
-// ï¿½ï¿½ï¿½ï¿½ï¿½ÅŒï¿½ï¿½ï¿½APIï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½ï¿½ÍAï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½ï¿½xï¿½ß‚ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½callï¿½B
-// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½jmpï¿½Rï¿½[ï¿½hï¿½É–ß‚ï¿½ï¿½B
+// “à•”‚ÅŒ³‚ÌAPI‚ğg‚¤‚ÍAƒR[ƒh‚ğˆê“x–ß‚µ‚Ä‚©‚çcallB
+// ‚·‚®‚ÉjmpƒR[ƒh‚É–ß‚·B
 //
-// ï¿½}ï¿½ï¿½ï¿½`ï¿½Xï¿½ï¿½ï¿½bï¿½hï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½callï¿½ï¿½ï¿½ï¿½ï¿½Æï¿½ï¿½ï¿½Ì‚ÅA
-// CriticalSectionï¿½Å”rï¿½ï¿½ï¿½ï¿½ï¿½ä‚µï¿½Ä‚ï¿½ï¿½ï¿½ï¿½B
+// ƒ}ƒ‹ƒ`ƒXƒŒƒbƒh‚Å ‘‚«Š·‚¦’†‚Écall‚³‚ê‚é‚Æ¢‚é‚Ì‚ÅA
+// CriticalSection‚Å”r‘¼§Œä‚µ‚Ä‚¨‚­B
 //
 
 #include "override.h"
@@ -43,7 +43,7 @@ HINSTANCE g_dllInstance;
 #include "detours.h"
 #pragma comment (lib, "detours.lib")
 #pragma comment (lib, "detoured.lib")
-// DATA_fooï¿½AORIG_foo ï¿½Ì‚Qï¿½Â‚ï¿½ï¿½Ü‚Æ‚ß‚Ä’ï¿½`ï¿½ï¿½ï¿½ï¿½}ï¿½Nï¿½ï¿½
+// DATA_fooAORIG_foo ‚Ì‚Q‚Â‚ğ‚Ü‚Æ‚ß‚Ä’è‹`‚·‚éƒ}ƒNƒ
 #define HOOK_MANUALLY HOOK_DEFINE
 #define HOOK_DEFINE(rettype, name, argtype) \
 	rettype (WINAPI * ORIG_##name) argtype;
@@ -143,7 +143,7 @@ static void hook_term()
 
 
 #define HOOK_DEFINE(rettype, name, argtype) \
-	HOOK_TRACE_INFO HOOK_##name = {0};	//ï¿½ï¿½ï¿½ï¿½hookï¿½á¹¹
+	HOOK_TRACE_INFO HOOK_##name = {0};	//½¨Á¢hook½á¹¹
 
 #include "hooklist.h"
 
@@ -243,7 +243,7 @@ HANDLE						g_hfDbgText;
 
 //#include "APITracer.hpp"
 
-//ï¿½xï¿½[ï¿½Xï¿½Aï¿½hï¿½ï¿½ï¿½Xï¿½ï¿½Ï‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½hï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½È‚ï¿½
+//ƒx[ƒXƒAƒhƒŒƒX‚ğ•Ï‚¦‚½•û‚ªƒ[ƒh‚ª‘‚­‚È‚é
 #if _DLL
 #pragma comment(linker, "/base:0x06540000")
 #endif
@@ -441,24 +441,24 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 			if (!hEasyhk) 
 				return false;			
 		}
-		//ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
-		//DLL_PROCESS_DETACHï¿½Å‚Í‚ï¿½ï¿½ï¿½Ì‹tï¿½ï¿½ï¿½É‚ï¿½ï¿½ï¿½
-		//1. CRTï¿½Öï¿½ï¿½Ìï¿½ï¿½ï¿½ï¿½ï¿½
-		//2. ï¿½Nï¿½ï¿½ï¿½eï¿½Bï¿½Jï¿½ï¿½ï¿½Zï¿½Nï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½Ìï¿½ï¿½ï¿½ï¿½ï¿½
-		//3. TLSï¿½Ìï¿½ï¿½ï¿½
-		//4. CGdippSettingsï¿½ÌƒCï¿½ï¿½ï¿½Xï¿½^ï¿½ï¿½ï¿½Xï¿½ï¿½ï¿½ï¿½ï¿½AINIï¿½Ç‚İï¿½ï¿½ï¿½
-		//5. ExcludeModuleï¿½`ï¿½Fï¿½bï¿½N
-		// 6. FreeTypeï¿½ï¿½ï¿½Cï¿½uï¿½ï¿½ï¿½ï¿½ï¿½Ìï¿½ï¿½ï¿½ï¿½ï¿½
-		// 7. FreeTypeFontEngineï¿½ÌƒCï¿½ï¿½ï¿½Xï¿½^ï¿½ï¿½ï¿½Xï¿½ï¿½ï¿½ï¿½
-		// 8. APIï¿½ï¿½ï¿½tï¿½bï¿½N
-		// 9. Managerï¿½ï¿½GetProcAddressï¿½ï¿½ï¿½tï¿½bï¿½N
+		//‰Šú‰»‡˜
+		//DLL_PROCESS_DETACH‚Å‚Í‚±‚ê‚Ì‹t‡‚É‚·‚é
+		//1. CRTŠÖ”‚Ì‰Šú‰»
+		//2. ƒNƒŠƒeƒBƒJƒ‹ƒZƒNƒVƒ‡ƒ“‚Ì‰Šú‰»
+		//3. TLS‚Ì€”õ
+		//4. CGdippSettings‚ÌƒCƒ“ƒXƒ^ƒ“ƒX¶¬AINI“Ç‚İ‚İ
+		//5. ExcludeModuleƒ`ƒFƒbƒN
+		// 6. FreeTypeƒ‰ƒCƒuƒ‰ƒŠ‚Ì‰Šú‰»
+		// 7. FreeTypeFontEngine‚ÌƒCƒ“ƒXƒ^ƒ“ƒX¶¬
+		// 8. API‚ğƒtƒbƒN
+		// 9. Manager‚ÌGetProcAddress‚ğƒtƒbƒN
 
 		//1
 		_CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) | _CRTDBG_LEAK_CHECK_DF);
 		_CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG | _CRTDBG_MODE_WNDW);
 		//_CrtSetBreakAlloc(100);
 
-		//Operaï¿½ï¿½~ï¿½Ü‚ï¿½`
+		//Opera‚æ~‚Ü‚ê`
 		//Assert(GetModuleHandleA("opera.exe") == NULL);
 		
 		setlocale(LC_ALL, "");
@@ -493,7 +493,7 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 			IsUnload = IsProcessUnload();
 			bEnableDW = pSettings->DirectWrite();
 		}
-		if (!IsUnload) hook_initinternal();	//ï¿½ï¿½ï¿½ï¿½ï¿½Øµï¿½Ä£ï¿½ï¿½Í²ï¿½ï¿½ï¿½ï¿½Îºï¿½ï¿½ï¿½ï¿½ï¿½
+		if (!IsUnload) hook_initinternal();	//²»¼ÓÔØµÄÄ£¿é¾Í²»×öÈÎºÎÊÂÇE
 		//5
 		if (!IsProcessExcluded() && !IsUnload) {
 #ifndef _WIN64
@@ -531,7 +531,7 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 			}*/
 //			InstallManagerHook();
 		}
-		//ï¿½ï¿½Ãµï¿½Ç°ï¿½ï¿½ï¿½ï¿½Ä£Ê½
+		//»ñµÃµ±Ç°¼ÓÔØÄ£Ê½
 
 		if (IsUnload)
 		{
@@ -542,11 +542,11 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 			HANDLE mutex_CompMode = OpenMutex(MUTEX_ALL_ACCESS, false, _T("Global\\MacTypeCompMode"));
 			if (!mutex_CompMode)			
 				mutex_CompMode = OpenMutex(MUTEX_ALL_ACCESS, false, _T("MacTypeCompMode"));
-			BOOL HookMode = (mutex_offical || (mutex_gditray2 && mutex_CompMode)) || (!mutex_offical && !mutex_gditray2);	//ï¿½Ç·ï¿½ï¿½Ú¼ï¿½ï¿½ï¿½Ä£Ê½ï¿½ï¿½
+			BOOL HookMode = (mutex_offical || (mutex_gditray2 && mutex_CompMode)) || (!mutex_offical && !mutex_gditray2);	//ÊÇ·ñÔÚ¼æÈİÄ£Ê½ÏÂ
 			CloseHandle(mutex_CompMode);
 			CloseHandle(mutex_gditray2);
 			CloseHandle(mutex_offical);
-			if (!HookMode)	//ï¿½Ç¼ï¿½ï¿½ï¿½Ä£Ê½ï¿½Â£ï¿½ï¿½Ü¾ï¿½ï¿½ï¿½ï¿½ï¿½
+			if (!HookMode)	//·Ç¼æÈİÄ£Ê½ÏÂ£¬¾Ü¾ø¼ÓÔØ
 				return false;
 		}
 
@@ -562,12 +562,12 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 		if (!bDllInited)
 			return true;
 		bDllInited = false;
-		if (InterlockedExchange(&g_bHookEnabled, FALSE) && lpReserved == NULL) {	//ï¿½ï¿½ï¿½ï¿½Ç½ï¿½ï¿½ï¿½ï¿½ï¿½Ö¹ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Òªï¿½Í·ï¿½
+		if (InterlockedExchange(&g_bHookEnabled, FALSE) && lpReserved == NULL) {	//Èç¹ûÊÇ½ø³ÌÖÕÖ¹£¬Ôò²»ĞèÒªÊÍ·Å
 			hook_term();
 			//delete AACacheFull;
 			//delete AACache;
 // 			for (int i=0;i<CACHE_SIZE;i++)
-// 				delete g_AACache2[i];	//ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+// 				delete g_AACache2[i];	//Çå³ı»º´E
 			//free(g_charmapCache);
 		}
 #ifndef DEBUG

--- a/hook.cpp
+++ b/hook.cpp
@@ -1,13 +1,13 @@
 // API hook
 //
-// GetProcAddress‚Å“¾‚½callæiŠÖ”–{‘Ìj‚ð’¼Ú‘‚«Š·‚¦A
-// Ž©•ª‚ÌƒtƒbƒNŠÖ”‚Éjmp‚³‚¹‚éB
+// GetProcAddressï¿½Å“ï¿½ï¿½ï¿½callï¿½ï¿½iï¿½Öï¿½ï¿½{ï¿½Ìjï¿½ð’¼Úï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½A
+// ï¿½ï¿½ï¿½ï¿½ï¿½Ìƒtï¿½bï¿½Nï¿½Öï¿½ï¿½ï¿½jmpï¿½ï¿½ï¿½ï¿½ï¿½ï¿½B
 //
-// “à•”‚ÅŒ³‚ÌAPI‚ðŽg‚¤Žž‚ÍAƒR[ƒh‚ðˆê“x–ß‚µ‚Ä‚©‚çcallB
-// ‚·‚®‚ÉjmpƒR[ƒh‚É–ß‚·B
+// ï¿½ï¿½ï¿½ï¿½ï¿½ÅŒï¿½ï¿½ï¿½APIï¿½ï¿½ï¿½gï¿½ï¿½ï¿½ï¿½ï¿½ÍAï¿½Rï¿½[ï¿½hï¿½ï¿½ï¿½ï¿½xï¿½ß‚ï¿½ï¿½Ä‚ï¿½ï¿½ï¿½callï¿½B
+// ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½jmpï¿½Rï¿½[ï¿½hï¿½É–ß‚ï¿½ï¿½B
 //
-// ƒ}ƒ‹ƒ`ƒXƒŒƒbƒh‚Å ‘‚«Š·‚¦’†‚Écall‚³‚ê‚é‚Æ¢‚é‚Ì‚ÅA
-// CriticalSection‚Å”r‘¼§Œä‚µ‚Ä‚¨‚­B
+// ï¿½}ï¿½ï¿½ï¿½`ï¿½Xï¿½ï¿½ï¿½bï¿½hï¿½ï¿½ ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½callï¿½ï¿½ï¿½ï¿½ï¿½Æï¿½ï¿½ï¿½Ì‚ÅA
+// CriticalSectionï¿½Å”rï¿½ï¿½ï¿½ï¿½ï¿½ä‚µï¿½Ä‚ï¿½ï¿½ï¿½ï¿½B
 //
 
 #include "override.h"
@@ -43,7 +43,7 @@ HINSTANCE g_dllInstance;
 #include "detours.h"
 #pragma comment (lib, "detours.lib")
 #pragma comment (lib, "detoured.lib")
-// DATA_fooAORIG_foo ‚Ì‚Q‚Â‚ð‚Ü‚Æ‚ß‚Ä’è‹`‚·‚éƒ}ƒNƒ
+// DATA_fooï¿½AORIG_foo ï¿½Ì‚Qï¿½Â‚ï¿½ï¿½Ü‚Æ‚ß‚Ä’ï¿½`ï¿½ï¿½ï¿½ï¿½}ï¿½Nï¿½ï¿½
 #define HOOK_MANUALLY HOOK_DEFINE
 #define HOOK_DEFINE(rettype, name, argtype) \
 	rettype (WINAPI * ORIG_##name) argtype;
@@ -129,9 +129,9 @@ static void hook_term()
 #else
 #include "easyhook.h"
 #ifdef _M_IX86
-#pragma comment (lib, "easyhk32.lib")
+#pragma comment (lib, "easyhook32.lib")
 #else
-#pragma comment (lib, "easyhk64.lib")
+#pragma comment (lib, "easyhook64.lib")
 #endif
 
 #define HOOK_MANUALLY HOOK_DEFINE
@@ -143,7 +143,7 @@ static void hook_term()
 
 
 #define HOOK_DEFINE(rettype, name, argtype) \
-	HOOK_TRACE_INFO HOOK_##name = {0};	//½¨Á¢hook½á¹¹
+	HOOK_TRACE_INFO HOOK_##name = {0};	//ï¿½ï¿½ï¿½ï¿½hookï¿½á¹¹
 
 #include "hooklist.h"
 
@@ -243,7 +243,7 @@ HANDLE						g_hfDbgText;
 
 //#include "APITracer.hpp"
 
-//ƒx[ƒXƒAƒhƒŒƒX‚ð•Ï‚¦‚½•û‚ªƒ[ƒh‚ª‘‚­‚È‚é
+//ï¿½xï¿½[ï¿½Xï¿½Aï¿½hï¿½ï¿½ï¿½Xï¿½ï¿½Ï‚ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½[ï¿½hï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½È‚ï¿½
 #if _DLL
 #pragma comment(linker, "/base:0x06540000")
 #endif
@@ -432,33 +432,33 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 			while (*--p != L'\\');
 			*p = L'\0';
 #ifdef _WIN64
-			wcscat(dllPath, L"\\EasyHk64.dll");
+			wcscat(dllPath, L"\\easyhook64.dll");
 #else
-			wcscat(dllPath, L"\\EasyHk32.dll");
+			wcscat(dllPath, L"\\easyhook32.dll");
 #endif
 			HMODULE hEasyhk = LoadLibrary(dllPath);
 			delete[]dllPath;
 			if (!hEasyhk) 
 				return false;			
 		}
-		//‰Šú‰»‡˜
-		//DLL_PROCESS_DETACH‚Å‚Í‚±‚ê‚Ì‹t‡‚É‚·‚é
-		//1. CRTŠÖ”‚Ì‰Šú‰»
-		//2. ƒNƒŠƒeƒBƒJƒ‹ƒZƒNƒVƒ‡ƒ“‚Ì‰Šú‰»
-		//3. TLS‚Ì€”õ
-		//4. CGdippSettings‚ÌƒCƒ“ƒXƒ^ƒ“ƒX¶¬AINI“Ç‚Ýž‚Ý
-		//5. ExcludeModuleƒ`ƒFƒbƒN
-		// 6. FreeTypeƒ‰ƒCƒuƒ‰ƒŠ‚Ì‰Šú‰»
-		// 7. FreeTypeFontEngine‚ÌƒCƒ“ƒXƒ^ƒ“ƒX¶¬
-		// 8. API‚ðƒtƒbƒN
-		// 9. Manager‚ÌGetProcAddress‚ðƒtƒbƒN
+		//ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
+		//DLL_PROCESS_DETACHï¿½Å‚Í‚ï¿½ï¿½ï¿½Ì‹tï¿½ï¿½ï¿½É‚ï¿½ï¿½ï¿½
+		//1. CRTï¿½Öï¿½ï¿½Ìï¿½ï¿½ï¿½ï¿½ï¿½
+		//2. ï¿½Nï¿½ï¿½ï¿½eï¿½Bï¿½Jï¿½ï¿½ï¿½Zï¿½Nï¿½Vï¿½ï¿½ï¿½ï¿½ï¿½Ìï¿½ï¿½ï¿½ï¿½ï¿½
+		//3. TLSï¿½Ìï¿½ï¿½ï¿½
+		//4. CGdippSettingsï¿½ÌƒCï¿½ï¿½ï¿½Xï¿½^ï¿½ï¿½ï¿½Xï¿½ï¿½ï¿½ï¿½ï¿½AINIï¿½Ç‚Ýï¿½ï¿½ï¿½
+		//5. ExcludeModuleï¿½`ï¿½Fï¿½bï¿½N
+		// 6. FreeTypeï¿½ï¿½ï¿½Cï¿½uï¿½ï¿½ï¿½ï¿½ï¿½Ìï¿½ï¿½ï¿½ï¿½ï¿½
+		// 7. FreeTypeFontEngineï¿½ÌƒCï¿½ï¿½ï¿½Xï¿½^ï¿½ï¿½ï¿½Xï¿½ï¿½ï¿½ï¿½
+		// 8. APIï¿½ï¿½ï¿½tï¿½bï¿½N
+		// 9. Managerï¿½ï¿½GetProcAddressï¿½ï¿½ï¿½tï¿½bï¿½N
 
 		//1
 		_CrtSetDbgFlag(_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) | _CRTDBG_LEAK_CHECK_DF);
 		_CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG | _CRTDBG_MODE_WNDW);
 		//_CrtSetBreakAlloc(100);
 
-		//Opera‚æŽ~‚Ü‚ê`
+		//Operaï¿½ï¿½~ï¿½Ü‚ï¿½`
 		//Assert(GetModuleHandleA("opera.exe") == NULL);
 		
 		setlocale(LC_ALL, "");
@@ -493,7 +493,7 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 			IsUnload = IsProcessUnload();
 			bEnableDW = pSettings->DirectWrite();
 		}
-		if (!IsUnload) hook_initinternal();	//²»¼ÓÔØµÄÄ£¿é¾Í²»×öÈÎºÎÊÂÇé
+		if (!IsUnload) hook_initinternal();	//ï¿½ï¿½ï¿½ï¿½ï¿½Øµï¿½Ä£ï¿½ï¿½Í²ï¿½ï¿½ï¿½ï¿½Îºï¿½ï¿½ï¿½ï¿½ï¿½
 		//5
 		if (!IsProcessExcluded() && !IsUnload) {
 #ifndef _WIN64
@@ -531,7 +531,7 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 			}*/
 //			InstallManagerHook();
 		}
-		//»ñµÃµ±Ç°¼ÓÔØÄ£Ê½
+		//ï¿½ï¿½Ãµï¿½Ç°ï¿½ï¿½ï¿½ï¿½Ä£Ê½
 
 		if (IsUnload)
 		{
@@ -542,11 +542,11 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 			HANDLE mutex_CompMode = OpenMutex(MUTEX_ALL_ACCESS, false, _T("Global\\MacTypeCompMode"));
 			if (!mutex_CompMode)			
 				mutex_CompMode = OpenMutex(MUTEX_ALL_ACCESS, false, _T("MacTypeCompMode"));
-			BOOL HookMode = (mutex_offical || (mutex_gditray2 && mutex_CompMode)) || (!mutex_offical && !mutex_gditray2);	//ÊÇ·ñÔÚ¼æÈÝÄ£Ê½ÏÂ
+			BOOL HookMode = (mutex_offical || (mutex_gditray2 && mutex_CompMode)) || (!mutex_offical && !mutex_gditray2);	//ï¿½Ç·ï¿½ï¿½Ú¼ï¿½ï¿½ï¿½Ä£Ê½ï¿½ï¿½
 			CloseHandle(mutex_CompMode);
 			CloseHandle(mutex_gditray2);
 			CloseHandle(mutex_offical);
-			if (!HookMode)	//·Ç¼æÈÝÄ£Ê½ÏÂ£¬¾Ü¾ø¼ÓÔØ
+			if (!HookMode)	//ï¿½Ç¼ï¿½ï¿½ï¿½Ä£Ê½ï¿½Â£ï¿½ï¿½Ü¾ï¿½ï¿½ï¿½ï¿½ï¿½
 				return false;
 		}
 
@@ -562,12 +562,12 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 		if (!bDllInited)
 			return true;
 		bDllInited = false;
-		if (InterlockedExchange(&g_bHookEnabled, FALSE) && lpReserved == NULL) {	//Èç¹ûÊÇ½ø³ÌÖÕÖ¹£¬Ôò²»ÐèÒªÊÍ·Å
+		if (InterlockedExchange(&g_bHookEnabled, FALSE) && lpReserved == NULL) {	//ï¿½ï¿½ï¿½ï¿½Ç½ï¿½ï¿½ï¿½ï¿½ï¿½Ö¹ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½Òªï¿½Í·ï¿½
 			hook_term();
 			//delete AACacheFull;
 			//delete AACache;
 // 			for (int i=0;i<CACHE_SIZE;i++)
-// 				delete g_AACache2[i];	//Çå³ý»º´æ
+// 				delete g_AACache2[i];	//ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½
 			//free(g_charmapCache);
 		}
 #ifndef DEBUG
@@ -587,9 +587,9 @@ BOOL WINAPI  DllMain(HINSTANCE instance, DWORD reason, LPVOID lpReserved)
 		FontLFree();
 /*
 #ifndef _WIN64
-		__FUnloadDelayLoadedDLL2("easyhk32.dll");
+		__FUnloadDelayLoadedDLL2("easyhook32.dll");
 #else
-		__FUnloadDelayLoadedDLL2("easyhk64.dll");
+		__FUnloadDelayLoadedDLL2("easyhook64.dll");
 #endif*/
 
 		CGdippSettings::DestroyInstance();


### PR DESCRIPTION
* Add freetype patch to repo
* Add the extra function's declaration to ft.cpp
* Replace `afxres.h` include with `winres.h` in `gdidll.rc` to avoid MFC dependency (not installed by VS by default anymore)
* Update toolset to v142
* Update Windows 10 SDK target to always latest installed.
* `INI_PARSER_PATH` and `FREETYPE_PATH` variables for include dirs instead of hardcoded paths
* `$(SolutionDir)lib` for library path to avoid having to modify it to build, also added to gitignore
* Fix build on v142 (string include missing in hash_list.h)
* Replace `easyhk` with `easyhook` so default builds of easyhook as well as distributed binaries work out of the box
* Update HOWTOBUILD.md