### PR TITLE
Fix build errors

### DIFF
--- a/doc/glyph_to_bitmapex.diff
+++ b/doc/glyph_to_bitmapex.diff
@@ -1,8 +1,3 @@
- src/base/ftglyph.c | 112 +++++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 file changed, 112 insertions(+)
-
-diff --git a/src/base/ftglyph.c b/src/base/ftglyph.c
-index 27402ecf8..7637388a8 100644
 --- a/src/base/ftglyph.c
 +++ b/src/base/ftglyph.c
 @@ -634,6 +634,118 @@
@@ -124,3 +119,20 @@ index 27402ecf8..7637388a8 100644
    /* documentation is in ftglyph.h */
  
    FT_EXPORT_DEF( void )
+--- a/include/freetype/ftglyph.h
++++ b/include/freetype/ftglyph.h
+@@ -574,6 +574,14 @@
+                       FT_Vector*      origin,
+                       FT_Bool         destroy );
+
++  FT_EXPORT(FT_Error)
++  FT_Glyph_To_BitmapEx(FT_Glyph* the_glyph,
++    FT_Render_Mode  render_mode,
++    FT_Vector* origin,
++    FT_Bool         destroy,
++    FT_Bool                    loadcolor,
++    FT_UInt                    glyphindex,
++    FT_Face                    face);
+
+   /**************************************************************************
+    *

--- a/ft.cpp
+++ b/ft.cpp
@@ -99,16 +99,6 @@ void Log(wchar_t* Msg)
 	fclose(f);
 }
 
-FT_EXPORT_DEF(FT_Error)
-FT_Glyph_To_BitmapEx(FT_Glyph* the_glyph,
-	FT_Render_Mode  render_mode,
-	FT_Vector* origin,
-	FT_Bool         destroy,
-	FT_Bool			loadcolor,
-	FT_UInt			glyphindex,
-	FT_Face			face);
-
-
 class CAlphaBlend
 {
 private:

--- a/gdipp.vcxproj
+++ b/gdipp.vcxproj
@@ -288,6 +288,7 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype.lib;usp10.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -315,6 +316,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype_inf.lib;usp10.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -344,6 +346,7 @@
       <PrecompiledHeader />
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype64.lib;usp10.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -374,6 +377,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype64.lib;usp10.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -402,6 +406,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype64.lib;usp10.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -429,6 +434,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype64.lib;usp10.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -458,7 +464,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(SolutionDir)deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zc:threadSafeInit- /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype.lib;usp10.lib;dwrite.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -492,6 +498,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype_inf.lib;usp10.lib;dwrite.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -525,6 +532,7 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>$(SolutionDir)deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype64.lib;usp10.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -559,6 +567,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype64_inf.lib;usp10.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -590,6 +599,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype64.lib;usp10.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -620,6 +630,7 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>freetype64.lib;usp10.lib;%(AdditionalDependencies)</AdditionalDependencies>


### PR DESCRIPTION
I tried to build the latest commit and it didn't work well. Here are the fixes.

* Visual Studio C++ compiler uses system ANSI encoding without `/utf-8` option. This caused confusing syntax errors.
*  I used FreeType 2.10.4 and `FT_EXPORT_DEF` was not available. Also `FT_Glyph_To_BitmapEx` was not exported, causing a linking error. So I added it to the diff file instead of `ft.cpp`.